### PR TITLE
Firmware version tweaks

### DIFF
--- a/combine.py
+++ b/combine.py
@@ -31,7 +31,7 @@ for i in range(0, len(certsData)):
 # zero terminate the pem file
 outputData[0x10000 + len(certsData)] = 0
 
-outputFilename = "NINA_W102.bin"
+outputFilename = "NINA_W102-1.3.0.bin"
 if (len(sys.argv) > 1):
 	outputFilename = sys.argv[1]
 

--- a/main/CommandHandler.cpp
+++ b/main/CommandHandler.cpp
@@ -26,7 +26,7 @@
 
 #include "CommandHandler.h"
 
-const char FIRMWARE_VERSION[6] = "1.2.2";
+const char FIRMWARE_VERSION[6] = "1.3.0";
 
 /*IPAddress*/uint32_t resolvedHostname;
 


### PR DESCRIPTION
I've rev'd the firmware version in CommandHandler.cpp and tweaked the combine.py script to include that same version number (though manually updated at the moment) in the generated firmware binary file. This will allow the companion CircuitPython code (updates and PR coming soon), or a human, to verify if a WPA2 Enterprise-enabled firmware is running on the WiFi co-processor.

My OCD kept telling me to make more changes to clean up the README.md and other things, but that starts pushing this code away from the original Arduino code base, and I'm not sure what the big picture plans are, so I left all that alone for now. I'd be happy to put my ideas into an email or some other form for discussion.