### PR TITLE
Add Travis CI Script for nina-fw

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ install:
 script:
   - cd $PROJECT_PATH
   - make firmware
-  - ls -la
 
 deploy:
   - provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,5 @@ deploy:
   api_key: "$GITHUB_TOKEN"
   file: "NINA_W102-*.bin"
   skip_cleanup: true
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   - cd ~/esp
   # Download binary toolchain for the ESP32
   - wget https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar.gz
-  - tar -xzf ~/Downloads/xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar.gz
+  - tar -xzf xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar.gz
   # Make xtensa-esp32-elf available for all terminal sessions
   - export PATH=$PATH:$HOME/esp/xtensa-esp32-elf/bin
   # Get ESP-IDF v3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ deploy:
   - provider: releases
     api_key: "$GITHUB_TOKEN"
     file_glob: true
-    file: "nina-fw.bin"
+    file: "NINA_W102-*.bin"
     skip_cleanup: true
     overwrite: true
     on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
   apt:
     packages:
       - python3.5
+      - gperf
 
 before_install:
   # Save path to the git respository

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,9 @@ script:
   - make firmware
 
 deploy:
-  - provider: releases
-    api_key: "$GITHUB_TOKEN"
-    file_glob: true
-    file: "NINA_W102-*.bin"
-    skip_cleanup: true
-    overwrite: true
-    on:
-      tags: true
+  provider: releases
+  api_key: "$GITHUB_TOKEN"
+  file: "NINA_W102-*.bin"
+  skip_cleanup: true
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,5 +40,3 @@ deploy:
   api_key: "$GITHUB_TOKEN"
   file: "NINA_W102-*.bin"
   skip_cleanup: true
-  on:
-    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,14 @@ install:
 script:
   - cd $PROJECT_PATH
   - make firmware
+  - ls -la
 
 deploy:
-  provider: releases
-  api_key: "GITHUB OAUTH TOKEN"
-  file: "FILE TO UPLOAD"
-  skip_cleanup: true
-  on:
-    tags: true
+  - provider: releases
+    api_key: "$GITHUB_TOKEN"
+    file_glob: true
+    file: "nina-fw.bin"
+    skip_cleanup: true
+    overwrite: true
+    on:
+      tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ os:
 addons:
   apt:
     packages:
-      - gperf
-      - python
+      - python3.6
 
 before_install:
   # Save path to the git respository
@@ -34,3 +33,11 @@ install:
 script:
   - cd $PROJECT_PATH
   - make firmware
+
+deploy:
+  provider: releases
+  api_key: "GITHUB OAUTH TOKEN"
+  file: "FILE TO UPLOAD"
+  skip_cleanup: true
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ os:
 addons:
   apt:
     packages:
-      - python3.6
+      - python3.5
 
 before_install:
   # Save path to the git respository

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ script:
 deploy:
   provider: releases
   api_key: "$GITHUB_TOKEN"
+  file_glob: true
   file: "NINA_W102-*.bin"
   skip_cleanup: true
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+# .travis.yml for nina-fw
+# adapted from https://github.com/igrr/esp32-cam-demo/blob/master/.travis.yml
+sudo: false
+language: bash
+os:
+  - linux
+
+addons:
+  apt:
+    packages:
+      - gperf
+      - python
+
+before_install:
+  # Save path to the git respository
+  - PROJECT_PATH=$(pwd)
+
+install:
+  - mkdir -p ~/esp
+  - cd ~/esp
+  # Download binary toolchain for the ESP32
+  - wget https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-61-gab8375a-5.2.0.tar.gz
+  - tar -xzf xtensa-esp32-elf-linux64-1.22.0-61-gab8375a-5.2.0.tar.gz
+  # Make xtensa-esp32-elf available for all terminal sessions
+  - export PATH=$PATH:$HOME/esp/xtensa-esp32-elf/bin
+  # Get ESP-IDF v3.3
+  - git clone --branch v3.3 --recursive https://github.com/espressif/esp-idf.git
+  # Set the path to ESP-IDF directory
+  - export IDF_PATH=~/esp/esp-idf 
+  # Install Required Python Packages
+  - python -m pip install --user -r $IDF_PATH/requirements.txt
+
+
+script:
+  - cd $PROJECT_PATH
+  - make firmware

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ install:
   - mkdir -p ~/esp
   - cd ~/esp
   # Download binary toolchain for the ESP32
-  - wget https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-61-gab8375a-5.2.0.tar.gz
-  - tar -xzf xtensa-esp32-elf-linux64-1.22.0-61-gab8375a-5.2.0.tar.gz
+  - wget https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar.gz
+  - tar -xzf ~/Downloads/xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar.gz
   # Make xtensa-esp32-elf available for all terminal sessions
   - export PATH=$PATH:$HOME/esp/xtensa-esp32-elf/bin
   # Get ESP-IDF v3.3

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Adafruit fork of the Arduino NINA-W102 firmware
 
+[![Build Status](https://travis-ci.com/adafruit/nina-fw.svg?branch=master)](https://travis-ci.com/adafruit/nina-fw)
+
 This is the Adafruit fork of the Arduino NINA-W102 firmware. The original
 repository is located at https://github.com/arduino/nina-fw
 


### PR DESCRIPTION
CI Script mirrors latest instructions in the [building section of this repository's README](https://github.com/adafruit/nina-fw/blob/master/README.md#building).

* Builds with ESP-IDF v3.3
  * NOTE: ESP-IDF releases new versions out-of-order (latest is 3.x.x per https://github.com/espressif/esp-idf/releases/latest). We'll need to manually change this within .travis.yml when we want to build/release for a new ESP-IDF version.
* Deploys firmware binaries on new `releases`
* Travis badge for README