### PR TITLE
Abstracted pinning from individual source files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,11 @@ CIRCUITPYTHON_UF2 := circuitpython.uf2
 
 EXTRA_COMPONENT_DIRS := $(PWD)/arduino
 
+# To use the new pinning, uncomment this line
+# CPPFLAGS +=-DOPTIMISED_PINNING
+
+CPPFLAGS +=-I$(PWD)
+
 ifeq ($(RELEASE),1)
 CFLAGS += -DNDEBUG -DCONFIG_FREERTOS_ASSERT_DISABLE -Os -DLOG_LOCAL_LEVEL=0
 CPPFLAGS += -DNDEBUG -Os

--- a/arduino/libraries/SPIS/src/SPIS.cpp
+++ b/arduino/libraries/SPIS/src/SPIS.cpp
@@ -26,6 +26,8 @@
 #include "WInterrupts.h"
 
 #include "SPIS.h"
+#include "pinning.h"
+
 
 SPISClass::SPISClass(spi_host_device_t hostDevice, int dmaChannel, int mosiPin, int misoPin, int sclkPin, int csPin, int readyPin) :
   _hostDevice(hostDevice),
@@ -113,4 +115,5 @@ void SPISClass::handleSetupComplete()
   xSemaphoreGiveFromISR(_readySemaphore, NULL);
 }
 
-SPISClass SPIS(VSPI_HOST, 1, 14, 23, 18, 5, 33);
+SPISClass SPIS(VSPI_HOST, VSPI_DMACHANNEL, VSPI_MOSI, VSPI_MISO, VSPI_SCLK, VSPI_SS, VSPI_READY);
+

--- a/pinning.h
+++ b/pinning.h
@@ -21,7 +21,7 @@
   #define VSPI_MISO       23
   #define VSPI_SCLK       18
   #define VSPI_SS         5
-  #define VSPI_READY      25
+  #define VSPI_READY      33
 
   #define BT_MODE_SENSE   5
   #define SWD_SAMD        15

--- a/pinning.h
+++ b/pinning.h
@@ -1,0 +1,43 @@
+#ifdef OPTIMISED_PINNING
+  #define VSPI_DMACHANNEL 1
+  #define VSPI_MOSI       19 /* IO0 */
+  #define VSPI_MISO       23 /* IO1 */
+  #define VSPI_SCLK       18 /* CLK */
+  #define VSPI_SS         5  /* CS */
+  #define VSPI_READY      21 /* IO3 */
+  #define VSPI_WP         22 /* IO2 */
+
+  #define UART1_TX        1
+  #define UART1_RX        3
+  #define UART1_RTS       33
+  #define UART1_CTS       32
+  #define UART1_BAUD      921600
+
+//BT_MODE_SENSE is not used with this pinning
+
+#else
+  #define VSPI_DMACHANNEL 1
+  #define VSPI_MOSI       14
+  #define VSPI_MISO       23
+  #define VSPI_SCLK       18
+  #define VSPI_SS         5
+  #define VSPI_READY      25
+
+  #define BT_MODE_SENSE   5
+  #define SWD_SAMD        15
+  #define SWCLK_SAMD      21
+
+  #ifdef UNO_WIFI_REV2
+    #define UART1_TX        1
+    #define UART1_RX        3
+    #define UART1_RTS       33
+    #define UART1_CTS       5
+    #define UART1_BAUD      115200
+  #else
+    #define UART1_TX        23
+    #define UART1_RX        12
+    #define UART1_RTS       18
+    #define UART1_CTS       5
+    #define UART1_BAUD      921600
+  #endif
+#endif


### PR DESCRIPTION
Moved pinning rules and definitions from individual source code files into a separate pinning.h file. Created alternate pinning which should be compatible with QSPI working, and running via the IOMUX for single bit SPI.

There should be no change in functionality unless the OPTIMISED_PINNING define is set in the makefile, but this needs testing on an existing target board (which, I'm afraid, I don't have) before this patch should be merged.