### PR TITLE
Fix BLE HCI mode

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Adafruit's Arduino NINA-W102 firmware 1.7.1 - 2020.10.24
+
+* Enable HCI BLE for AirLift boards and breakouts.
+
 Adafruit's Arduino NINA-W102 firmware 1.6.0 - 2019.12.28
 
 * Updated to build with ESP-IDF 3.3.1

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ load-passthrough:
 	cp passthrough.UF2  $(BOOT_VOLUME)
 
 load-nina:
-	esptool.py --port $(M4_PORT) --before no_reset --baud $(UPLOAD_BAUD) write_flash 0 NINA_W102-1.7.0.bin
+	esptool.py --port $(M4_PORT) --before no_reset --baud $(UPLOAD_BAUD) write_flash 0 NINA_W102-1.7.1.bin
 
 load-circuitpython:
 	cp $(CIRCUITPYTHON_UF2) $(BOOT_VOLUME)

--- a/combine.py
+++ b/combine.py
@@ -31,7 +31,7 @@ for i in range(0, len(certsData)):
 # zero terminate the pem file
 outputData[0x10000 + len(certsData)] = 0
 
-outputFilename = "NINA_W102-1.7.0.bin"
+outputFilename = "NINA_W102-1.7.1.bin"
 if (len(sys.argv) > 1):
 	outputFilename = sys.argv[1]
 

--- a/main/CommandHandler.cpp
+++ b/main/CommandHandler.cpp
@@ -28,7 +28,7 @@
 
 #include "Arduino.h"
 
-const char FIRMWARE_VERSION[6] = "1.7.0";
+const char FIRMWARE_VERSION[6] = "1.7.1";
 
 // Optional, user-defined X.509 certificate
 char CERT_BUF[1300];

--- a/main/sketch.ino.cpp
+++ b/main/sketch.ino.cpp
@@ -108,10 +108,6 @@ void setup() {
 void setupBluetooth() {
   if (debug)  ets_printf("setup periph\n");
 
-  while (1) {
-    vTaskDelay(portMAX_DELAY);
-  }
-
   periph_module_enable(PERIPH_UART1_MODULE);
   periph_module_enable(PERIPH_UHCI0_MODULE);
 
@@ -132,7 +128,7 @@ void setupBluetooth() {
 
   if (debug)  ets_printf("setup controller\n");
 
-  esp_bt_controller_config_t btControllerConfig = BT_CONTROLLER_INIT_CONFIG_DEFAULT(); 
+  esp_bt_controller_config_t btControllerConfig = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
 
   btControllerConfig.hci_uart_no = UART_NUM_1;
 #ifdef UNO_WIFI_REV2
@@ -152,6 +148,7 @@ void setupBluetooth() {
 
   vTaskSuspend(NULL);
 
+  // Don't exit. We don't need loop() to run.
   while (1) {
     vTaskDelay(portMAX_DELAY);
     if (debug)  ets_printf(".");


### PR DESCRIPTION
There was a spurious infinite loop in `setupBluetooth()` in `main/sketch.ino.cpp`, which prevented the BLE setup from finishing.

Bumped to version 1.7.1.

Tested with a UART echo test.