### PR TITLE
Added INPUT_PULLUP support and let analog write use full PWM range

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-Adafruit's Arduino NINA-W102 firmware 1.7.2 - 2021.03.22
+Adafruit's Arduino NINA-W102 firmware 1.7.3 - 2021.03.26
 
 * Changed Analog Write to use full PWM range.
 * Added support to Pin Mode for INPUT_PULLUP.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Adafruit's Arduino NINA-W102 firmware 1.7.2 - 2021.03.22
+
+* Changed Analog Write to use full PWM range.
+* Added support to Pin Mode for INPUT_PULLUP.
+
 Adafruit's Arduino NINA-W102 firmware 1.7.1 - 2020.10.24
 
 * Enable HCI BLE for AirLift boards and breakouts.

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ load-passthrough:
 	cp passthrough.UF2  $(BOOT_VOLUME)
 
 load-nina:
-	esptool.py --port $(M4_PORT) --before no_reset --baud $(UPLOAD_BAUD) write_flash 0 NINA_W102-1.7.2.bin
+	esptool.py --port $(M4_PORT) --before no_reset --baud $(UPLOAD_BAUD) write_flash 0 NINA_W102-1.7.3.bin
 
 load-circuitpython:
 	cp $(CIRCUITPYTHON_UF2) $(BOOT_VOLUME)

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ load-passthrough:
 	cp passthrough.UF2  $(BOOT_VOLUME)
 
 load-nina:
-	esptool.py --port $(M4_PORT) --before no_reset --baud $(UPLOAD_BAUD) write_flash 0 NINA_W102-1.7.1.bin
+	esptool.py --port $(M4_PORT) --before no_reset --baud $(UPLOAD_BAUD) write_flash 0 NINA_W102-1.7.2.bin
 
 load-circuitpython:
 	cp $(CIRCUITPYTHON_UF2) $(BOOT_VOLUME)

--- a/arduino/cores/esp32/wiring_analog.c
+++ b/arduino/cores/esp32/wiring_analog.c
@@ -38,7 +38,7 @@ void analogWrite(uint32_t pin, uint32_t value)
 
   ledc_channel_config_t ledc_conf = {
     .channel = (pin % 7),
-    .duty = (value << 2),
+    .duty = (value << 2) | ((value & 0xC0) >> 6),
     .gpio_num = pin,
     .intr_type = LEDC_INTR_DISABLE,
     .speed_mode = LEDC_HIGH_SPEED_MODE,

--- a/arduino/cores/esp32/wiring_digital.c
+++ b/arduino/cores/esp32/wiring_digital.c
@@ -33,6 +33,11 @@ void pinMode(uint32_t pin, uint32_t mode)
       gpio_set_direction((gpio_num_t)pin, GPIO_MODE_OUTPUT);
       gpio_set_pull_mode((gpio_num_t)pin, GPIO_FLOATING);
       break;
+
+    case INPUT_PULLUP:
+      gpio_set_direction((gpio_num_t)pin, GPIO_MODE_INPUT);
+      gpio_set_pull_mode((gpio_num_t)pin, GPIO_PULLUP_ONLY);
+      break;
   }
 
   PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin], PIN_FUNC_GPIO);

--- a/arduino/cores/esp32/wiring_digital.h
+++ b/arduino/cores/esp32/wiring_digital.h
@@ -31,6 +31,7 @@ extern "C" {
 
 #define INPUT  0x00
 #define OUTPUT 0x01
+#define INPUT_PULLUP 0x02
 
 extern void pinMode(uint32_t pin, uint32_t mode);
 

--- a/combine.py
+++ b/combine.py
@@ -31,7 +31,7 @@ for i in range(0, len(certsData)):
 # zero terminate the pem file
 outputData[0x10000 + len(certsData)] = 0
 
-outputFilename = "NINA_W102-1.7.2.bin"
+outputFilename = "NINA_W102-1.7.3.bin"
 if (len(sys.argv) > 1):
 	outputFilename = sys.argv[1]
 

--- a/combine.py
+++ b/combine.py
@@ -31,7 +31,7 @@ for i in range(0, len(certsData)):
 # zero terminate the pem file
 outputData[0x10000 + len(certsData)] = 0
 
-outputFilename = "NINA_W102-1.7.1.bin"
+outputFilename = "NINA_W102-1.7.2.bin"
 if (len(sys.argv) > 1):
 	outputFilename = sys.argv[1]
 

--- a/main/CommandHandler.cpp
+++ b/main/CommandHandler.cpp
@@ -28,7 +28,7 @@
 
 #include "Arduino.h"
 
-const char FIRMWARE_VERSION[6] = "1.7.1";
+const char FIRMWARE_VERSION[6] = "1.7.2";
 
 // Optional, user-defined X.509 certificate
 char CERT_BUF[1300];

--- a/main/CommandHandler.cpp
+++ b/main/CommandHandler.cpp
@@ -28,7 +28,7 @@
 
 #include "Arduino.h"
 
-const char FIRMWARE_VERSION[6] = "1.7.2";
+const char FIRMWARE_VERSION[6] = "1.7.3";
 
 // Optional, user-defined X.509 certificate
 char CERT_BUF[1300];


### PR DESCRIPTION
Made two tweaks to the firmware to support an upcoming Pimoroni product. Specifically:

- Added support to pinMode for INPUT_PULLUP, so digitalRead is easier to use with buttons
- Updated analogWrite to use the full PWM range, so that common anode LEDs can be turned off

Have built the firmware locally under Ubuntu 18.04 LTS and tested these two changes work.