### PR TITLE
Fix setHostname API

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Adafruit's Arduino NINA-W102 firmware 1.7.4 - 2021.06.03
+
+* Fixed support for custom hostname in WiFi client mode
+
 Adafruit's Arduino NINA-W102 firmware 1.7.3 - 2021.03.26
 
 * Changed Analog Write to use full PWM range.

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ load-passthrough:
 	cp passthrough.UF2  $(BOOT_VOLUME)
 
 load-nina:
-	esptool.py --port $(M4_PORT) --before no_reset --baud $(UPLOAD_BAUD) write_flash 0 NINA_W102-1.7.3.bin
+	esptool.py --port $(M4_PORT) --before no_reset --baud $(UPLOAD_BAUD) write_flash 0 NINA_W102-1.7.4.bin
 
 load-circuitpython:
 	cp $(CIRCUITPYTHON_UF2) $(BOOT_VOLUME)

--- a/arduino/libraries/WiFi/src/WiFi.cpp
+++ b/arduino/libraries/WiFi/src/WiFi.cpp
@@ -44,6 +44,7 @@ WiFiClass::WiFiClass() :
   memset(&_apRecord, 0x00, sizeof(_apRecord));
   memset(&_ipInfo, 0x00, sizeof(_ipInfo));
   memset(&_dnsServers, 0x00, sizeof(_dnsServers));
+  memset(&_hostname, 0x00, sizeof(_hostname));
 }
 
 uint8_t WiFiClass::status()
@@ -320,7 +321,7 @@ void WiFiClass::setDNS(/*IPAddress*/uint32_t dns_server1, /*IPAddress*/uint32_t 
 
 void WiFiClass::hostname(const char* name)
 {
-  tcpip_adapter_set_hostname(_interface == ESP_IF_WIFI_AP ? TCPIP_ADAPTER_IF_AP : TCPIP_ADAPTER_IF_STA, name);
+  strncpy(_hostname, name, HOSTNAME_MAX_LENGTH);
 }
 
 void WiFiClass::disconnect()
@@ -604,7 +605,12 @@ void WiFiClass::handleSystemEvent(system_event_t* event)
 
       esp_wifi_get_mac(ESP_IF_WIFI_STA, mac);
       sprintf(defaultHostname, "arduino-%.2x%.2x", mac[4], mac[5]);
-      tcpip_adapter_set_hostname(TCPIP_ADAPTER_IF_STA, defaultHostname);
+      //tcpip_adapter_set_hostname(TCPIP_ADAPTER_IF_STA, defaultHostname);
+      if (strlen(_hostname) == 0) {
+        sprintf(_hostname, "%s", defaultHostname);
+      }
+      tcpip_adapter_set_hostname(_interface == ESP_IF_WIFI_AP ? TCPIP_ADAPTER_IF_AP : TCPIP_ADAPTER_IF_STA, _hostname);
+
 
       if (tcpip_adapter_get_netif(TCPIP_ADAPTER_IF_STA, (void**)&staNetif) == ESP_OK) {
         if (staNetif->input != WiFiClass::staNetifInputHandler) {

--- a/arduino/libraries/WiFi/src/WiFi.h
+++ b/arduino/libraries/WiFi/src/WiFi.h
@@ -44,6 +44,7 @@ typedef enum {
 } wl_status_t;
 
 #define MAX_SCAN_RESULTS 10
+#define HOSTNAME_MAX_LENGTH 32
 
 class WiFiClass
 {
@@ -119,6 +120,7 @@ private:
   tcpip_adapter_ip_info_t _ipInfo;
   uint32_t _dnsServers[2];
 
+  char _hostname[HOSTNAME_MAX_LENGTH+1];
   netif_input_fn _staNetifInput;
   netif_input_fn _apNetifInput;
 

--- a/combine.py
+++ b/combine.py
@@ -31,7 +31,7 @@ for i in range(0, len(certsData)):
 # zero terminate the pem file
 outputData[0x10000 + len(certsData)] = 0
 
-outputFilename = "NINA_W102-1.7.3.bin"
+outputFilename = "NINA_W102-1.7.4.bin"
 if (len(sys.argv) > 1):
 	outputFilename = sys.argv[1]
 

--- a/main/CommandHandler.cpp
+++ b/main/CommandHandler.cpp
@@ -28,7 +28,7 @@
 
 #include "Arduino.h"
 
-const char FIRMWARE_VERSION[6] = "1.7.3";
+const char FIRMWARE_VERSION[6] = "1.7.4";
 
 // Optional, user-defined X.509 certificate
 char CERT_BUF[1300];


### PR DESCRIPTION
Slightly modified version of the upstream fix to the set hostname API,
found here: https://github.com/adafruit/nina-fw/commit/f63b70aa3d4091003248f22bd1a176dfb9ce7e77

Sets the custom hostname in the system STA_START event, rather than directly. Falls back to "defaultHostname"

Allows a custom client-mode hostname to be set.

Fixes #35 

Not exactly thoroughly tested! :grimacing: 