### PR TITLE
Insert v1.7.2 notes into CHANGELOG

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,10 @@ Adafruit's Arduino NINA-W102 firmware 1.7.3 - 2021.03.26
 * Changed Analog Write to use full PWM range.
 * Added support to Pin Mode for INPUT_PULLUP.
 
+Adafruit's Arduino NINA-W102 firmware 1.7.2 - 2021.03.05
+
+* Replace peek() with available() during connection status check to avoid losing messages.
+
 Adafruit's Arduino NINA-W102 firmware 1.7.1 - 2020.10.24
 
 * Enable HCI BLE for AirLift boards and breakouts.


### PR DESCRIPTION
As noticed in https://github.com/adafruit/nina-fw/pull/36 this change grabs the text from https://github.com/adafruit/nina-fw/pull/31 and inserts it into the CHANGELOG so that the change in v1.7.2 is documented.