### PR TITLE
add gh action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,13 @@
 name: Build
 
 on:
-  workflow_dispatch:
+  repository_dispatch:
   push:
   pull_request:
     branches: [ master ]
+  release:
+    types:
+      - created
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build
+
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+    branches: [ master ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build-esp:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+
+    - name: Pull ESP-IDF docker
+      run: docker pull espressif/idf:v3.3.1
+
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build
+      run: docker run --rm -v $PWD:/project -w /project espressif/idf:v3.3.1 make firmware
+
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: NINA_W102-${{ github.sha }}
+        path: |
+          NINA_W102*.bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-esp:
+  build:
     runs-on: ubuntu-latest
     steps:
     - name: Setup Python
@@ -33,4 +33,11 @@ jobs:
       with:
         name: NINA_W102-${{ github.sha }}
         path: |
+          NINA_W102*.bin
+
+    - name: Upload Release Asset
+      uses: softprops/action-gh-release@v1
+      if: ${{ github.event_name == 'release' }}
+      with:
+        files: |
           NINA_W102*.bin

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ load-passthrough:
 	cp passthrough.UF2  $(BOOT_VOLUME)
 
 load-nina:
-	esptool.py --port $(M4_PORT) --before no_reset --baud $(UPLOAD_BAUD) write_flash 0 NINA_W102-1.7.6.bin
+	esptool.py --port $(M4_PORT) --before no_reset --baud $(UPLOAD_BAUD) write_flash 0 $(wildcard NINA_W102-*.bin)
 
 load-circuitpython:
 	cp $(CIRCUITPYTHON_UF2) $(BOOT_VOLUME)

--- a/README.md
+++ b/README.md
@@ -15,10 +15,8 @@ Contributors who follow the [Code of Conduct](https://github.com/adafruit/nina-f
 are welcome to submit pull requests and they will be promptly
 reviewed by project admins. Please join the [Discord](https://adafru.it/discord) too.
 
-The NINA firmware version needs to be updated in four places in this repo:
+The NINA firmware version needs to be updated in two places in this repo:
 1. CommandHandler.cpp
-1. combine.py
-1. Makefile
 1. CHANGELOG
 
 ## Building

--- a/combine.py
+++ b/combine.py
@@ -2,6 +2,17 @@
 
 import sys;
 
+
+def extract_firmware_version():
+	with open('main/CommandHandler.cpp', 'r') as file:
+		for line in file:
+			if 'const char FIRMWARE_VERSION[6] = ' in line:
+				# The line format is `const char FIRMWARE_VERSION[6] = "1.7.6";`
+				# Split by double quote and get the second element
+				version = line.split('"')[1]
+				return version
+
+
 booloaderData = open("build/bootloader/bootloader.bin", "rb").read()
 partitionData = open("build/partitions.bin", "rb").read()
 appData = open("build/nina-fw.bin", "rb").read()
@@ -31,7 +42,9 @@ for i in range(0, len(certsData)):
 # zero terminate the pem file
 outputData[0x10000 + len(certsData)] = 0
 
-outputFilename = "NINA_W102-1.7.6.bin"
+version = extract_firmware_version()
+outputFilename = f"NINA_W102-{version}.bin"
+
 if (len(sys.argv) > 1):
 	outputFilename = sys.argv[1]
 


### PR DESCRIPTION
This repo use rather old IDF v3.3.1, which can cause trouble for some to build. Although I have no issue on Linux, having gh ci build and upload bin file as commit & release artifacts is a nice addition. This will help to safe check changes.

Also take the chance to reudce firmware version duplicaiton
- combine.py extract version from CommandHandler.cpp
- make load-nina use wildcard to load bin file